### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/UltimateRecyclerView/ultimaterecyclerview/src/main/AndroidManifest.xml
+++ b/UltimateRecyclerView/ultimaterecyclerview/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.marshalchen.ultimaterecyclerview">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher">
-
-    </application>
+  
 
 </manifest>


### PR DESCRIPTION
if the line is not removed then app gives that;

Error:(15, 9) Attribute application@icon value=(@mipmap/ic_launcher) from AndroidManifest.xml:15:9
	is also present at com.marshalchen.ultimaterecyclerview:library:0.1.0:13:9 value=(@drawable/ic_launcher)
	Suggestion: add 'tools:replace="android:icon"' to <application> element at AndroidManifest.xml:12:5 to override

useless line should be removed.